### PR TITLE
Resolve bin issue "* does not exist" when installed via Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,11 @@
   "homepage": "https://github.com/Hashnode/mern-cli#readme",
   "bin": {
     "mern": "./bin/mern.js",
-    "merng": "./bin/merng.js"
+    "merng": "./bin/merng.js",
+    "mern-info": "./bin/mern-info.js",
+    "mern-init": "./bin/mern-init.js",
+    "mern-list": "./bin/mern-list.js",
+    "mern-search": "./bin/mern-search.js"
   },
   "dependencies": {
     "chalk": "^1.1.1",


### PR DESCRIPTION
This PR is a proposed solution to the following issue: https://github.com/Hashnode/mern-cli/issues/21.

I saw that `mern-cli` uses commander.js to run the commands, however I am not familiar with that tool and opted to solve the issue similarly to https://github.com/vuejs/vue-cli/pull/206.

Please let me know if there is anything I can do to help either get this merged in or work out another solution.