### PR TITLE
Destructure the object, not the desired property

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -20,7 +20,7 @@ const printBlueprint = (blueprint) => {
 
 program.on('--help', () => {
     // Get available blueprints from the current mern project
-    const { blueprints } = getMernConfig().blueprints;
+    const { blueprints } = getMernConfig();
     console.log(chalk.yellow('Available Generators'));
     console.log(chalk.yellow('____________________'));
     console.log('');


### PR DESCRIPTION
I got the following error:

```
Usage: merng [options] <generator> [args]

Generate components, routes, controllers, models using mern generator

Options:
  -h, --help  output usage information
Available Generators
____________________

$PREFIX/lib/node_modules/mern-cli/lib/commands/generate.js:43
    blueprints.forEach(function (b) {
               ^

TypeError: Cannot read property 'forEach' of undefined
    at Command.<anonymous> ($PREFIX/lib/node_modules/mern-cli/lib/commands/generate.js:43:16)
    at Command.emit (events.js:182:13)
    at Command.outputHelp ($PREFIX/lib/node_modules/mern-cli/node_modules/commander/index.js:1142:8)
    at Command.help ($PREFIX/lib/node_modules/mern-cli/node_modules/commander/index.js:1152:8)
    at Object.<anonymous> ($PREFIX/lib/node_modules/mern-cli/lib/commands/generate.js:49:25)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```

This fixes it.