### PR TITLE
Validates whether projectName follows npm conventions

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "elegant-spinner": "^1.0.1",
     "log-update": "^2.3.0",
     "shelljs": "^0.8.2",
+    "validate-npm-package-name": "^3.0.0",
     "writefile": "^0.2.8"
   },
   "devDependencies": {

--- a/src/commands/main-init.js
+++ b/src/commands/main-init.js
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import elegantSpinner from 'elegant-spinner';
 import logUpdate from 'log-update';
 import variants from '../../variants.json';
+import validate from 'validate-npm-package-name';
 
 require('shelljs/global');
 
@@ -22,6 +23,16 @@ if (program.args.length > 1) {
     console.log(chalk.red('Please give only one argument as a directory name!!!'));
     exit(1);
 }
+
+const validationResult = validate(program.args[0]);
+if (!validationResult.validForNewPackages) {
+    console.error(
+      `Could not create a project called ${chalk.red(
+        `"${program.args[0]}"`
+    )} because of npm naming restrictions:`
+    );
+    exit(1);
+} 
 
 if (program.args.length === 1) {
     if (test('-d', program.args[0])) {


### PR DESCRIPTION
closes #42
Warns the user if special characters are used for the projectName in `mern init <projectName>`
> Also, makes sure that the it is as per the npm package naming conventions.